### PR TITLE
Document Ubuntu libcanberra-gtk-module dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Fedora/RedHat distros:
 
 Ubuntu/Mint/Debian distros:
 
-    sudo apt install sassc optipng inkscape libcanberra-gtk-module
+    sudo apt install sassc optipng inkscape libcanberra-gtk-module libglib2.0-dev
 
 Debian 10:
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Fedora/RedHat distros:
 
 Ubuntu/Mint/Debian distros:
 
-    sudo apt install sassc optipng inkscape
+    sudo apt install sassc optipng inkscape libcanberra-gtk-module
 
 Debian 10:
 


### PR DESCRIPTION
Minor docs update, but when building this on Ubuntu 20.04 LTS I had to install `libcanberra-gtk-module` and `libglib2.0-dev` so I've updated the relevant Ubuntu dependency README lines.