### PR TITLE
Fix #145

### DIFF
--- a/render-assets.sh
+++ b/render-assets.sh
@@ -43,7 +43,7 @@ render_thumbnail() {
     else
       $INKSCAPE --export-id=thumbnail$2 \
                 --export-id-only \
-                --export-png=$ASRC_DIR/$1/thumbnail$2.png $ASRC_DIR/$1/thumbnail.svg >/dev/null
+                --export-filename=$ASRC_DIR/$1/thumbnail$2.png $ASRC_DIR/$1/thumbnail.svg >/dev/null
     fi
 
     $OPTIPNG -o7 --quiet $ASRC_DIR/$1/thumbnail$2.png

--- a/src/assets/gtk-2.0/render-assets.sh
+++ b/src/assets/gtk-2.0/render-assets.sh
@@ -34,7 +34,7 @@ else
     else
       $INKSCAPE --export-id=$i \
                 --export-id-only \
-                --export-png=$LIGHT_ASSETS_DIR/$i.png $LIGHT_SRC_FILE >/dev/null
+                --export-filename=$LIGHT_ASSETS_DIR/$i.png $LIGHT_SRC_FILE >/dev/null
     fi
 
     $OPTIPNG -o7 --quiet $LIGHT_ASSETS_DIR/$i.png
@@ -53,7 +53,7 @@ else
     else
       $INKSCAPE --export-id=$i \
                 --export-id-only \
-                --export-png=$DARK_ASSETS_DIR/$i.png $DARK_SRC_FILE >/dev/null
+                --export-filename=$DARK_ASSETS_DIR/$i.png $DARK_SRC_FILE >/dev/null
     fi
 
     $OPTIPNG -o7 --quiet $DARK_ASSETS_DIR/$i.png

--- a/src/assets/gtk-3.0/common-assets/render-assets.sh
+++ b/src/assets/gtk-3.0/common-assets/render-assets.sh
@@ -29,7 +29,7 @@ else
     else
       $INKSCAPE --export-id=$i \
                 --export-id-only \
-                --export-png=$ASSETS_DIR/$i.png $SRC_FILE >/dev/null
+                --export-filename=$ASSETS_DIR/$i.png $SRC_FILE >/dev/null
     fi
 
     $OPTIPNG -o7 --quiet $ASSETS_DIR/$i.png
@@ -50,7 +50,7 @@ else
       $INKSCAPE --export-id=$i \
                 --export-dpi=180 \
                 --export-id-only \
-                --export-png=$ASSETS_DIR/$i@2.png $SRC_FILE >/dev/null
+                --export-filename=$ASSETS_DIR/$i@2.png $SRC_FILE >/dev/null
     fi
 
     $OPTIPNG -o7 --quiet $ASSETS_DIR/$i@2.png

--- a/src/assets/gtk-3.0/windows-assets/render-alt-assets.sh
+++ b/src/assets/gtk-3.0/windows-assets/render-alt-assets.sh
@@ -31,7 +31,7 @@ else
     else
       $INKSCAPE --export-id=$i-alt$d \
                 --export-id-only \
-                --export-png=$ASSETS_DIR/$i$d.png $SRC_FILE >/dev/null
+                --export-filename=$ASSETS_DIR/$i$d.png $SRC_FILE >/dev/null
     fi
 
     $OPTIPNG -o7 --quiet $ASSETS_DIR/$i$d.png
@@ -51,7 +51,7 @@ else
     else
       $INKSCAPE --export-id=$i-alt$d \
                 --export-id-only \
-                --export-png=$ASSETS_DIR/$i$d@2.png $SRC_FILE >/dev/null
+                --export-filename=$ASSETS_DIR/$i$d@2.png $SRC_FILE >/dev/null
     fi
 
     $OPTIPNG -o7 --quiet $ASSETS_DIR/$i$d@2.png

--- a/src/assets/gtk-3.0/windows-assets/render-alt-small-assets.sh
+++ b/src/assets/gtk-3.0/windows-assets/render-alt-small-assets.sh
@@ -31,7 +31,7 @@ else
     else
       $INKSCAPE --export-id=$i-alt-small$d \
                 --export-id-only \
-                --export-png=$ASSETS_DIR/$i$d.png $SRC_FILE >/dev/null
+                --export-filename=$ASSETS_DIR/$i$d.png $SRC_FILE >/dev/null
     fi
 
     $OPTIPNG -o7 --quiet $ASSETS_DIR/$i$d.png 
@@ -52,7 +52,7 @@ else
       $INKSCAPE --export-id=$i-alt-small$d \
                 --export-dpi=180 \
                 --export-id-only \
-                --export-png=$ASSETS_DIR/$i$d@2.png $SRC_FILE >/dev/null
+                --export-filename=$ASSETS_DIR/$i$d@2.png $SRC_FILE >/dev/null
     fi
 
     $OPTIPNG -o7 --quiet $ASSETS_DIR/$i$d@2.png 

--- a/src/assets/gtk-3.0/windows-assets/render-assets.sh
+++ b/src/assets/gtk-3.0/windows-assets/render-assets.sh
@@ -31,7 +31,7 @@ else
     else
       $INKSCAPE --export-id=$i$d \
                 --export-id-only \
-                --export-png=$ASSETS_DIR/$i$d.png $SRC_FILE >/dev/null
+                --export-filename=$ASSETS_DIR/$i$d.png $SRC_FILE >/dev/null
     fi
 
     $OPTIPNG -o7 --quiet $ASSETS_DIR/$i$d.png 
@@ -52,7 +52,7 @@ else
       $INKSCAPE --export-id=$i$d \
                 --export-dpi=180 \
                 --export-id-only \
-                --export-png=$ASSETS_DIR/$i$d@2.png $SRC_FILE >/dev/null
+                --export-filename=$ASSETS_DIR/$i$d@2.png $SRC_FILE >/dev/null
     fi
 
     $OPTIPNG -o7 --quiet $ASSETS_DIR/$i$d@2.png 

--- a/src/assets/gtk-3.0/windows-assets/render-small-assets.sh
+++ b/src/assets/gtk-3.0/windows-assets/render-small-assets.sh
@@ -31,7 +31,7 @@ else
     else
       $INKSCAPE --export-id=$i-small$d \
                 --export-id-only \
-                --export-png=$ASSETS_DIR/$i$d.png $SRC_FILE >/dev/null
+                --export-filename=$ASSETS_DIR/$i$d.png $SRC_FILE >/dev/null
     fi
 
     $OPTIPNG -o7 --quiet $ASSETS_DIR/$i$d.png 
@@ -52,7 +52,7 @@ else
       $INKSCAPE --export-id=$i-small$d \
                 --export-dpi=180 \
                 --export-id-only \
-                --export-png=$ASSETS_DIR/$i$d@2.png $SRC_FILE >/dev/null
+                --export-filename=$ASSETS_DIR/$i$d@2.png $SRC_FILE >/dev/null
     fi
 
     $OPTIPNG -o7 --quiet $ASSETS_DIR/$i$d@2.png 

--- a/src/assets/metacity-1/render-assets.sh
+++ b/src/assets/metacity-1/render-assets.sh
@@ -29,7 +29,7 @@ else
     else
       $INKSCAPE --export-id=$i \
                 --export-id-only \
-                --export-png=$ASSETS_DIR/$i.png $SRC_FILE >/dev/null
+                --export-filename=$ASSETS_DIR/$i.png $SRC_FILE >/dev/null
     fi
 
     $OPTIPNG -o7 --quiet $ASSETS_DIR/$i.png

--- a/src/assets/xfwm4/render-assets.sh
+++ b/src/assets/xfwm4/render-assets.sh
@@ -32,7 +32,7 @@ else
     else
       $INKSCAPE --export-id=$i \
                 --export-id-only \
-                --export-png=$ASSETS_DIR/$i.png $SRC_FILE >/dev/null
+                --export-filename=$ASSETS_DIR/$i.png $SRC_FILE >/dev/null
     fi
 
     $OPTIPNG -o7 --quiet $ASSETS_DIR/$i.png
@@ -50,7 +50,7 @@ else
     else
       $INKSCAPE --export-id=$i \
                 --export-id-only \
-                --export-png=$DARK_ASSETS_DIR/$i.png $DARK_SRC_FILE >/dev/null
+                --export-filename=$DARK_ASSETS_DIR/$i.png $DARK_SRC_FILE >/dev/null
     fi
 
     $OPTIPNG -o7 --quiet $DARK_ASSETS_DIR/$i.png


### PR DESCRIPTION
The reason why the error exist is because it's for inkscape 0.9.

Dnf and flatpak is releasing inkscape 1.0, so the `--export-png` option is now changed to `export-filename`

Haven't tested on inkscape 0.9 though, it might break things.