### PR TITLE
Fix filename in Install tips section

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ After depends all installed you can Run
 
 #### Install tips
 
-Usage:  `./Install`  **[OPTIONS...]**
+Usage:  `./install.sh`  **[OPTIONS...]**
 
 |  OPTIONS:           | |
 |:--------------------|:-------------|


### PR DESCRIPTION
This refers to the filename install.sh, which here simply was written Install. An experienced user will understand this and correct it, but a beginner might be confused as to why it does not work. This pull request fixes this error.