### PR TITLE
fix disabled items visibility in gnome shell

### DIFF
--- a/src/sass/gnome-shell/_common.scss
+++ b/src/sass/gnome-shell/_common.scss
@@ -783,7 +783,7 @@ $selected_slider_color: white;
   .popup-inactive-menu-item { //all icons and other graphical elements
     color: $fg_color;
 
-    &:insensitive { color: transparent; }
+    &:insensitive { color: $disabled_fg_color; }
   }
 
   //.popup-status-menu-item { font-weight: normal;  color: pink; } //dunno what that is


### PR DESCRIPTION
Disabled items in popup menus in top bar were invisible. This fixes it.