### PR TITLE
A lot of fixes, including fixing installation on macOS (does not support cp -u) and relative path resolution

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -50,92 +50,92 @@ usage() {
 }
 
 install() {
-  local dest=${1}
-  local name=${2}
-  local color=${3}
-  local opacity=${4}
-  local alt=${5}
-  local small=${6}
-  local icon=${7}
+  local dest="${1}"
+  local name="${2}"
+  local color="${3}"
+  local opacity="${4}"
+  local alt="${5}"
+  local small="${6}"
+  local icon="${7}"
 
-  [[ ${color} == '-light' ]] && local ELSE_LIGHT=${color}
-  [[ ${color} == '-dark' ]] && local ELSE_DARK=${color}
+  [[ "${color}" == '-light' ]] && local ELSE_LIGHT="${color}"
+  [[ "${color}" == '-dark' ]] && local ELSE_DARK="${color}"
 
-  local THEME_DIR=${1}/${2}${3}${4}${5}${6}
+  local THEME_DIR="${1}/${2}${3}${4}${5}${6}"
 
-  [[ -d ${THEME_DIR} ]] && rm -rf ${THEME_DIR}
+  [[ -d "${THEME_DIR}" ]] && rm -rf "${THEME_DIR}"
 
   echo "Installing '${THEME_DIR}'..."
 
-  mkdir -p                                                                              ${THEME_DIR}
-  copy_r ${REPO_DIR}/COPYING                                                            ${THEME_DIR}
+  mkdir -p                                                                                  "${THEME_DIR}"
+  copy_r "${REPO_DIR}/COPYING"                                                              "${THEME_DIR}"
 
-  echo "[Desktop Entry]" >>                                                             ${THEME_DIR}/index.theme
-  echo "Type=X-GNOME-Metatheme" >>                                                      ${THEME_DIR}/index.theme
-  echo "Name=${name}${color}${opacity}${alt}${small}" >>                                ${THEME_DIR}/index.theme
-  echo "Comment=An Stylish Gtk+ theme based on Elegant Design" >>                       ${THEME_DIR}/index.theme
-  echo "Encoding=UTF-8" >>                                                              ${THEME_DIR}/index.theme
-  echo "" >>                                                                            ${THEME_DIR}/index.theme
-  echo "[X-GNOME-Metatheme]" >>                                                         ${THEME_DIR}/index.theme
-  echo "GtkTheme=${name}${color}${opacity}${alt}${small}" >>                            ${THEME_DIR}/index.theme
-  echo "MetacityTheme=${name}${color}${opacity}${alt}${small}" >>                       ${THEME_DIR}/index.theme
-  echo "IconTheme=Adwaita" >>                                                           ${THEME_DIR}/index.theme
-  echo "CursorTheme=Adwaita" >>                                                         ${THEME_DIR}/index.theme
-  echo "ButtonLayout=close,minimize,maximize:menu" >>                                   ${THEME_DIR}/index.theme
+  echo "[Desktop Entry]" >>                                                                 "${THEME_DIR}/index.theme"
+  echo "Type=X-GNOME-Metatheme" >>                                                          "${THEME_DIR}/index.theme"
+  echo "Name=${name}${color}${opacity}${alt}${small}" >>                                    "${THEME_DIR}/index.theme"
+  echo "Comment=An Stylish Gtk+ theme based on Elegant Design" >>                           "${THEME_DIR}/index.theme"
+  echo "Encoding=UTF-8" >>                                                                  "${THEME_DIR}/index.theme"
+  echo "" >>                                                                                "${THEME_DIR}/index.theme"
+  echo "[X-GNOME-Metatheme]" >>                                                             "${THEME_DIR}/index.theme"
+  echo "GtkTheme=${name}${color}${opacity}${alt}${small}" >>                                "${THEME_DIR}/index.theme"
+  echo "MetacityTheme=${name}${color}${opacity}${alt}${small}" >>                           "${THEME_DIR}/index.theme"
+  echo "IconTheme=Adwaita" >>                                                               "${THEME_DIR}/index.theme"
+  echo "CursorTheme=Adwaita" >>                                                             "${THEME_DIR}/index.theme"
+  echo "ButtonLayout=close,minimize,maximize:menu" >>                                       "${THEME_DIR}/index.theme"
 
-  mkdir -p                                                                              ${THEME_DIR}/gnome-shell
-  copy_r ${SRC_DIR}/main/gnome-shell/gnome-shell${color}${opacity}.css                  ${THEME_DIR}/gnome-shell/gnome-shell.css
-  copy_r ${SRC_DIR}/assets/gnome-shell/common-assets                                    ${THEME_DIR}/gnome-shell/assets
-  copy_r ${SRC_DIR}/assets/gnome-shell/assets${color}/*.svg                             ${THEME_DIR}/gnome-shell/assets
-  copy_r ${SRC_DIR}/assets/gnome-shell/assets${color}/background.png                    ${THEME_DIR}/gnome-shell/assets
-  copy_r ${SRC_DIR}/assets/gnome-shell/assets${color}/activities/activities${icon}.svg  ${THEME_DIR}/gnome-shell/assets/activities.svg
-  cd ${THEME_DIR}/gnome-shell
+  mkdir -p                                                                                  "${THEME_DIR}/gnome-shell"
+  copy_r "${SRC_DIR}/main/gnome-shell/gnome-shell${color}${opacity}.css"                    "${THEME_DIR}/gnome-shell/gnome-shell.css"
+  copy_r "${SRC_DIR}/assets/gnome-shell/common-assets"                                      "${THEME_DIR}/gnome-shell/assets"
+  copy_r "${SRC_DIR}/assets/gnome-shell/assets${color}/"*'.svg'                             "${THEME_DIR}/gnome-shell/assets"
+  copy_r "${SRC_DIR}/assets/gnome-shell/assets${color}/background.png"                      "${THEME_DIR}/gnome-shell/assets"
+  copy_r "${SRC_DIR}/assets/gnome-shell/assets${color}/activities/activities${icon}.svg"    "${THEME_DIR}/gnome-shell/assets/activities.svg"
+  cd "${THEME_DIR}/gnome-shell"
   ln -s assets/no-events.svg no-events.svg
   ln -s assets/process-working.svg process-working.svg
   ln -s assets/no-notifications.svg no-notifications.svg
 
-  mkdir -p                                                                              ${THEME_DIR}/gtk-2.0
-  copy_r ${SRC_DIR}/main/gtk-2.0/gtkrc${color}                                          ${THEME_DIR}/gtk-2.0/gtkrc
-  copy_r ${SRC_DIR}/main/gtk-2.0/menubar-toolbar${color}.rc                             ${THEME_DIR}/gtk-2.0/menubar-toolbar.rc
-  copy_r ${SRC_DIR}/main/gtk-2.0/common/*.rc                                            ${THEME_DIR}/gtk-2.0
-  copy_r ${SRC_DIR}/assets/gtk-2.0/assets${color}                                       ${THEME_DIR}/gtk-2.0/assets
+  mkdir -p                                                                                  "${THEME_DIR}/gtk-2.0"
+  copy_r "${SRC_DIR}/main/gtk-2.0/gtkrc${color}"                                            "${THEME_DIR}/gtk-2.0/gtkrc"
+  copy_r "${SRC_DIR}/main/gtk-2.0/menubar-toolbar${color}.rc"                               "${THEME_DIR}/gtk-2.0/menubar-toolbar.rc"
+  copy_r "${SRC_DIR}/main/gtk-2.0/common/"*'.rc'                                            "${THEME_DIR}/gtk-2.0"
+  copy_r "${SRC_DIR}/assets/gtk-2.0/assets${color}"                                         "${THEME_DIR}/gtk-2.0/assets"
 
-  mkdir -p                                                                              ${THEME_DIR}/gtk-3.0
-  copy_r ${SRC_DIR}/assets/gtk-3.0/common-assets/assets                                 ${THEME_DIR}/gtk-3.0
-  copy_r ${SRC_DIR}/assets/gtk-3.0/windows-assets/titlebutton${alt}${small}             ${THEME_DIR}/gtk-3.0/windows-assets
-  copy_r ${SRC_DIR}/assets/gtk-3.0/thumbnail${color}.png                                ${THEME_DIR}/gtk-3.0/thumbnail.png
-  copy_r ${SRC_DIR}/main/gtk-3.0/gtk-dark${opacity}.css                                 ${THEME_DIR}/gtk-3.0/gtk-dark.css
+  mkdir -p                                                                                  "${THEME_DIR}/gtk-3.0"
+  copy_r "${SRC_DIR}/assets/gtk-3.0/common-assets/assets"                                   "${THEME_DIR}/gtk-3.0"
+  copy_r "${SRC_DIR}/assets/gtk-3.0/windows-assets/titlebutton${alt}${small}"               "${THEME_DIR}/gtk-3.0/windows-assets"
+  copy_r "${SRC_DIR}/assets/gtk-3.0/thumbnail${color}.png"                                  "${THEME_DIR}/gtk-3.0/thumbnail.png"
+  copy_r "${SRC_DIR}/main/gtk-3.0/gtk-dark${opacity}.css"                                   "${THEME_DIR}/gtk-3.0/gtk-dark.css"
 
-  if [[ ${color} == '-light' ]]; then
-    copy_r ${SRC_DIR}/main/gtk-3.0/gtk-light${opacity}.css                              ${THEME_DIR}/gtk-3.0/gtk.css
+  if [[ "${color}" == '-light' ]]; then
+    copy_r "${SRC_DIR}/main/gtk-3.0/gtk-light${opacity}.css"                                "${THEME_DIR}/gtk-3.0/gtk.css"
   else
-    copy_r ${SRC_DIR}/main/gtk-3.0/gtk-dark${opacity}.css                               ${THEME_DIR}/gtk-3.0/gtk.css
+    copy_r "${SRC_DIR}/main/gtk-3.0/gtk-dark${opacity}.css"                                 "${THEME_DIR}/gtk-3.0/gtk.css"
   fi
 
-  glib-compile-resources --sourcedir=${THEME_DIR}/gtk-3.0 --target=${THEME_DIR}/gtk-3.0/gtk.gresource ${SRC_DIR}/main/gtk-3.0/gtk.gresource.xml
-  rm -rf ${THEME_DIR}/gtk-3.0/{assets,windows-assets,gtk.css,gtk-dark.css}
-  echo '@import url("resource:///org/gnome/Mojave-theme/gtk.css");' >>                  ${THEME_DIR}/gtk-3.0/gtk.css
-  echo '@import url("resource:///org/gnome/Mojave-theme/gtk-dark.css");' >>             ${THEME_DIR}/gtk-3.0/gtk-dark.css
+  glib-compile-resources --sourcedir="${THEME_DIR}/gtk-3.0" --target="${THEME_DIR}/gtk-3.0/gtk.gresource" "${SRC_DIR}/main/gtk-3.0/gtk.gresource.xml"
+  rm -rf "${THEME_DIR}/gtk-3.0/"{assets,windows-assets,gtk.css,gtk-dark.css}
+  echo '@import url("resource:///org/gnome/Mojave-theme/gtk.css");' >>                      "${THEME_DIR}/gtk-3.0/gtk.css"
+  echo '@import url("resource:///org/gnome/Mojave-theme/gtk-dark.css");' >>                 "${THEME_DIR}/gtk-3.0/gtk-dark.css"
 
-  mkdir -p                                                                              ${THEME_DIR}/metacity-1
-  copy_r ${SRC_DIR}/main/metacity-1/metacity-theme${color}.xml                          ${THEME_DIR}/metacity-1/metacity-theme-1.xml
-  copy_r ${SRC_DIR}/main/metacity-1/metacity-theme-3.xml                                ${THEME_DIR}/metacity-1
-  copy_r ${SRC_DIR}/assets/metacity-1/assets/*.png                                      ${THEME_DIR}/metacity-1
-  copy_r ${SRC_DIR}/assets/metacity-1/thumbnail${color}.png                             ${THEME_DIR}/metacity-1/thumbnail.png
-  cd ${THEME_DIR}/metacity-1 && ln -s metacity-theme-1.xml metacity-theme-2.xml
+  mkdir -p                                                                                  "${THEME_DIR}/metacity-1"
+  copy_r "${SRC_DIR}/main/metacity-1/metacity-theme${color}.xml"                            "${THEME_DIR}/metacity-1/metacity-theme-1.xml"
+  copy_r "${SRC_DIR}/main/metacity-1/metacity-theme-3.xml"                                  "${THEME_DIR}/metacity-1"
+  copy_r "${SRC_DIR}/assets/metacity-1/assets/"*'.png'                                      "${THEME_DIR}/metacity-1"
+  copy_r "${SRC_DIR}/assets/metacity-1/thumbnail${color}.png"                               "${THEME_DIR}/metacity-1/thumbnail.png"
+  cd "${THEME_DIR}/metacity-1" && ln -s metacity-theme-1.xml metacity-theme-2.xml
 
-  mkdir -p                                                                              ${THEME_DIR}/xfwm4
-  copy_r ${SRC_DIR}/assets/xfwm4/assets${color}/*.png                                   ${THEME_DIR}/xfwm4
-  copy_r ${SRC_DIR}/main/xfwm4/themerc${color}                                          ${THEME_DIR}/xfwm4/themerc
+  mkdir -p                                                                                  "${THEME_DIR}/xfwm4"
+  copy_r "${SRC_DIR}/assets/xfwm4/assets${color}/"*'.png'                                   "${THEME_DIR}/xfwm4"
+  copy_r "${SRC_DIR}/main/xfwm4/themerc${color}"                                            "${THEME_DIR}/xfwm4/themerc"
 
-  mkdir -p                                                                              ${THEME_DIR}/cinnamon
-  copy_r ${SRC_DIR}/main/cinnamon/cinnamon${color}${opacity}.css                        ${THEME_DIR}/cinnamon/cinnamon.css
-  copy_r ${SRC_DIR}/assets/cinnamon/common-assets                                       ${THEME_DIR}/cinnamon/assets
-  copy_r ${SRC_DIR}/assets/cinnamon/assets${color}/*.svg                                ${THEME_DIR}/cinnamon/assets
-  copy_r ${SRC_DIR}/assets/cinnamon/thumbnail${color}.png                               ${THEME_DIR}/cinnamon/thumbnail.png
+  mkdir -p                                                                                  "${THEME_DIR}/cinnamon"
+  copy_r "${SRC_DIR}/main/cinnamon/cinnamon${color}${opacity}.css"                          "${THEME_DIR}/cinnamon/cinnamon.css"
+  copy_r "${SRC_DIR}/assets/cinnamon/common-assets"                                         "${THEME_DIR}/cinnamon/assets"
+  copy_r "${SRC_DIR}/assets/cinnamon/assets${color}/"*'.svg'                                "${THEME_DIR}/cinnamon/assets"
+  copy_r "${SRC_DIR}/assets/cinnamon/thumbnail${color}.png"                                 "${THEME_DIR}/cinnamon/thumbnail.png"
 
-  mkdir -p                                                                              ${THEME_DIR}/plank
-  copy_r ${SRC_DIR}/other/plank/${name}${color}/*.theme                                 ${THEME_DIR}/plank
+  mkdir -p                                                                                  "${THEME_DIR}/plank"
+  copy_r "${SRC_DIR}/other/plank/${name}${color}/"*'.theme'                                 "${THEME_DIR}/plank"
 }
 
 # Backup and install files related to GDM theme
@@ -181,7 +181,7 @@ install_gdm() {
     cp -an "$ETC_THEME_FILE" "$ETC_THEME_FILE.bak"
     # rm -rf "$ETC_THEME_FILE" "$GS_THEME_FILE"
     # mv "$GS_THEME_FILE.bak" "$GS_THEME_FILE"
-    [[ -d $SHELL_THEME_FOLDER/Mojave ]] && rm -rf $SHELL_THEME_FOLDER/Mojave
+    [[ -d "$SHELL_THEME_FOLDER/Mojave" ]] && rm -rf "$SHELL_THEME_FOLDER/Mojave"
     copy_r "$GDM_THEME_DIR/gnome-shell" "$SHELL_THEME_FOLDER/Mojave"
     cd "$ETC_THEME_FOLDER"
     ln -s "$SHELL_THEME_FOLDER/Mojave/gnome-shell.css" gdm3.css
@@ -211,7 +211,7 @@ revert_gdm() {
     echo "reverting Ubuntu gnome-shell theme..."
     rm -rf "$ETC_THEME_FILE"
     mv "$ETC_THEME_FILE.bak" "$ETC_THEME_FILE"
-    [[ -d $SHELL_THEME_FOLDER/Mojave ]] && rm -rf $SHELL_THEME_FOLDER/Mojave
+    [[ -d "$SHELL_THEME_FOLDER/Mojave" ]] && rm -rf "$SHELL_THEME_FOLDER/Mojave"
   fi
 }
 
@@ -408,11 +408,11 @@ for opacity in "${opacities[@]-${OPACITY_VARIANTS[@]}}"; do
 done
 }
 
-${REPO_DIR}/parse-sass.sh
+"${REPO_DIR}/parse-sass.sh"
 
 #./render-assets.sh
 
-cd ${SRC_DIR}/main/gtk-3.0 && ./make_gresource_xml.sh
+cd "${SRC_DIR}/main/gtk-3.0" && ./make_gresource_xml.sh
 
 #if [[ "${small:-}" == 'small' ]]; then
 #  cd ${SRC_DIR}/assets/gtk-3.0/windows-assets && ./render-small-assets.sh && ./render-alt-small-assets.sh

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 set -ueo pipefail
 set -o physical
 #set -x
@@ -219,11 +219,12 @@ revert_gdm() {
 while [[ $# -gt 0 ]]; do
   case "${1}" in
     -d|--dest)
-      dest="$(cd "${2}"; pwd)"
+      dest="${2}"
       if [[ ! -d "${dest}" ]]; then
         echo "Destination directory does not exist. Let's make a new one..."
         mkdir -p "${dest}"
       fi
+      dest="$(cd "${dest}"; pwd)"
       shift 2
       ;;
     -n|--name)

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -ueo pipefail
+set -o physical
 #set -x
 
 REPO_DIR=$(cd $(dirname $0) && pwd)
@@ -218,10 +219,10 @@ revert_gdm() {
 while [[ $# -gt 0 ]]; do
   case "${1}" in
     -d|--dest)
-      dest="${2}"
+      dest="$(cd "${2}"; pwd)"
       if [[ ! -d "${dest}" ]]; then
         echo "Destination directory does not exist. Let's make a new one..."
-        mkdir -p ${dest}
+        mkdir -p "${dest}"
       fi
       shift 2
       ;;

--- a/install.sh
+++ b/install.sh
@@ -3,8 +3,8 @@ set -ueo pipefail
 set -o physical
 #set -x
 
-REPO_DIR=$(cd $(dirname $0) && pwd)
-SRC_DIR=${REPO_DIR}/src
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+SRC_DIR="${REPO_DIR}/src"
 
 ROOT_UID=0
 DEST_DIR=

--- a/install.sh
+++ b/install.sh
@@ -22,6 +22,17 @@ ALT_VARIANTS=('' '-alt')
 SMALL_VARIANTS=('' '-small')
 ICON_VARIANTS=('' '-normal' '-gnome' '-ubuntu' '-arch' '-manjaro' '-fedora' '-debian' '-void')
 
+copy_r() {
+	case "$(uname -s)" in
+		'FreeBSD'|'Darwin')
+			cp -r "${@}"
+			;;
+		*)
+			cp -ur "${@}"
+			;;
+	esac
+}
+
 usage() {
   printf "%s\n" "Usage: $0 [OPTIONS...]"
   printf "\n%s\n" "OPTIONS:"
@@ -56,7 +67,7 @@ install() {
   echo "Installing '${THEME_DIR}'..."
 
   mkdir -p                                                                              ${THEME_DIR}
-  cp -ur ${REPO_DIR}/COPYING                                                            ${THEME_DIR}
+  copy_r ${REPO_DIR}/COPYING                                                            ${THEME_DIR}
 
   echo "[Desktop Entry]" >>                                                             ${THEME_DIR}/index.theme
   echo "Type=X-GNOME-Metatheme" >>                                                      ${THEME_DIR}/index.theme
@@ -72,32 +83,32 @@ install() {
   echo "ButtonLayout=close,minimize,maximize:menu" >>                                   ${THEME_DIR}/index.theme
 
   mkdir -p                                                                              ${THEME_DIR}/gnome-shell
-  cp -ur ${SRC_DIR}/main/gnome-shell/gnome-shell${color}${opacity}.css                  ${THEME_DIR}/gnome-shell/gnome-shell.css
-  cp -ur ${SRC_DIR}/assets/gnome-shell/common-assets                                    ${THEME_DIR}/gnome-shell/assets
-  cp -ur ${SRC_DIR}/assets/gnome-shell/assets${color}/*.svg                             ${THEME_DIR}/gnome-shell/assets
-  cp -ur ${SRC_DIR}/assets/gnome-shell/assets${color}/background.png                    ${THEME_DIR}/gnome-shell/assets
-  cp -ur ${SRC_DIR}/assets/gnome-shell/assets${color}/activities/activities${icon}.svg  ${THEME_DIR}/gnome-shell/assets/activities.svg
+  copy_r ${SRC_DIR}/main/gnome-shell/gnome-shell${color}${opacity}.css                  ${THEME_DIR}/gnome-shell/gnome-shell.css
+  copy_r ${SRC_DIR}/assets/gnome-shell/common-assets                                    ${THEME_DIR}/gnome-shell/assets
+  copy_r ${SRC_DIR}/assets/gnome-shell/assets${color}/*.svg                             ${THEME_DIR}/gnome-shell/assets
+  copy_r ${SRC_DIR}/assets/gnome-shell/assets${color}/background.png                    ${THEME_DIR}/gnome-shell/assets
+  copy_r ${SRC_DIR}/assets/gnome-shell/assets${color}/activities/activities${icon}.svg  ${THEME_DIR}/gnome-shell/assets/activities.svg
   cd ${THEME_DIR}/gnome-shell
   ln -s assets/no-events.svg no-events.svg
   ln -s assets/process-working.svg process-working.svg
   ln -s assets/no-notifications.svg no-notifications.svg
 
   mkdir -p                                                                              ${THEME_DIR}/gtk-2.0
-  cp -ur ${SRC_DIR}/main/gtk-2.0/gtkrc${color}                                          ${THEME_DIR}/gtk-2.0/gtkrc
-  cp -ur ${SRC_DIR}/main/gtk-2.0/menubar-toolbar${color}.rc                             ${THEME_DIR}/gtk-2.0/menubar-toolbar.rc
-  cp -ur ${SRC_DIR}/main/gtk-2.0/common/*.rc                                            ${THEME_DIR}/gtk-2.0
-  cp -ur ${SRC_DIR}/assets/gtk-2.0/assets${color}                                       ${THEME_DIR}/gtk-2.0/assets
+  copy_r ${SRC_DIR}/main/gtk-2.0/gtkrc${color}                                          ${THEME_DIR}/gtk-2.0/gtkrc
+  copy_r ${SRC_DIR}/main/gtk-2.0/menubar-toolbar${color}.rc                             ${THEME_DIR}/gtk-2.0/menubar-toolbar.rc
+  copy_r ${SRC_DIR}/main/gtk-2.0/common/*.rc                                            ${THEME_DIR}/gtk-2.0
+  copy_r ${SRC_DIR}/assets/gtk-2.0/assets${color}                                       ${THEME_DIR}/gtk-2.0/assets
 
   mkdir -p                                                                              ${THEME_DIR}/gtk-3.0
-  cp -ur ${SRC_DIR}/assets/gtk-3.0/common-assets/assets                                 ${THEME_DIR}/gtk-3.0
-  cp -ur ${SRC_DIR}/assets/gtk-3.0/windows-assets/titlebutton${alt}${small}             ${THEME_DIR}/gtk-3.0/windows-assets
-  cp -ur ${SRC_DIR}/assets/gtk-3.0/thumbnail${color}.png                                ${THEME_DIR}/gtk-3.0/thumbnail.png
-  cp -ur ${SRC_DIR}/main/gtk-3.0/gtk-dark${opacity}.css                                 ${THEME_DIR}/gtk-3.0/gtk-dark.css
+  copy_r ${SRC_DIR}/assets/gtk-3.0/common-assets/assets                                 ${THEME_DIR}/gtk-3.0
+  copy_r ${SRC_DIR}/assets/gtk-3.0/windows-assets/titlebutton${alt}${small}             ${THEME_DIR}/gtk-3.0/windows-assets
+  copy_r ${SRC_DIR}/assets/gtk-3.0/thumbnail${color}.png                                ${THEME_DIR}/gtk-3.0/thumbnail.png
+  copy_r ${SRC_DIR}/main/gtk-3.0/gtk-dark${opacity}.css                                 ${THEME_DIR}/gtk-3.0/gtk-dark.css
 
   if [[ ${color} == '-light' ]]; then
-    cp -ur ${SRC_DIR}/main/gtk-3.0/gtk-light${opacity}.css                              ${THEME_DIR}/gtk-3.0/gtk.css
+    copy_r ${SRC_DIR}/main/gtk-3.0/gtk-light${opacity}.css                              ${THEME_DIR}/gtk-3.0/gtk.css
   else
-    cp -ur ${SRC_DIR}/main/gtk-3.0/gtk-dark${opacity}.css                               ${THEME_DIR}/gtk-3.0/gtk.css
+    copy_r ${SRC_DIR}/main/gtk-3.0/gtk-dark${opacity}.css                               ${THEME_DIR}/gtk-3.0/gtk.css
   fi
 
   glib-compile-resources --sourcedir=${THEME_DIR}/gtk-3.0 --target=${THEME_DIR}/gtk-3.0/gtk.gresource ${SRC_DIR}/main/gtk-3.0/gtk.gresource.xml
@@ -106,24 +117,24 @@ install() {
   echo '@import url("resource:///org/gnome/Mojave-theme/gtk-dark.css");' >>             ${THEME_DIR}/gtk-3.0/gtk-dark.css
 
   mkdir -p                                                                              ${THEME_DIR}/metacity-1
-  cp -ur ${SRC_DIR}/main/metacity-1/metacity-theme${color}.xml                          ${THEME_DIR}/metacity-1/metacity-theme-1.xml
-  cp -ur ${SRC_DIR}/main/metacity-1/metacity-theme-3.xml                                ${THEME_DIR}/metacity-1
-  cp -ur ${SRC_DIR}/assets/metacity-1/assets/*.png                                      ${THEME_DIR}/metacity-1
-  cp -ur ${SRC_DIR}/assets/metacity-1/thumbnail${color}.png                             ${THEME_DIR}/metacity-1/thumbnail.png
+  copy_r ${SRC_DIR}/main/metacity-1/metacity-theme${color}.xml                          ${THEME_DIR}/metacity-1/metacity-theme-1.xml
+  copy_r ${SRC_DIR}/main/metacity-1/metacity-theme-3.xml                                ${THEME_DIR}/metacity-1
+  copy_r ${SRC_DIR}/assets/metacity-1/assets/*.png                                      ${THEME_DIR}/metacity-1
+  copy_r ${SRC_DIR}/assets/metacity-1/thumbnail${color}.png                             ${THEME_DIR}/metacity-1/thumbnail.png
   cd ${THEME_DIR}/metacity-1 && ln -s metacity-theme-1.xml metacity-theme-2.xml
 
   mkdir -p                                                                              ${THEME_DIR}/xfwm4
-  cp -ur ${SRC_DIR}/assets/xfwm4/assets${color}/*.png                                   ${THEME_DIR}/xfwm4
-  cp -ur ${SRC_DIR}/main/xfwm4/themerc${color}                                          ${THEME_DIR}/xfwm4/themerc
+  copy_r ${SRC_DIR}/assets/xfwm4/assets${color}/*.png                                   ${THEME_DIR}/xfwm4
+  copy_r ${SRC_DIR}/main/xfwm4/themerc${color}                                          ${THEME_DIR}/xfwm4/themerc
 
   mkdir -p                                                                              ${THEME_DIR}/cinnamon
-  cp -ur ${SRC_DIR}/main/cinnamon/cinnamon${color}${opacity}.css                        ${THEME_DIR}/cinnamon/cinnamon.css
-  cp -ur ${SRC_DIR}/assets/cinnamon/common-assets                                       ${THEME_DIR}/cinnamon/assets
-  cp -ur ${SRC_DIR}/assets/cinnamon/assets${color}/*.svg                                ${THEME_DIR}/cinnamon/assets
-  cp -ur ${SRC_DIR}/assets/cinnamon/thumbnail${color}.png                               ${THEME_DIR}/cinnamon/thumbnail.png
+  copy_r ${SRC_DIR}/main/cinnamon/cinnamon${color}${opacity}.css                        ${THEME_DIR}/cinnamon/cinnamon.css
+  copy_r ${SRC_DIR}/assets/cinnamon/common-assets                                       ${THEME_DIR}/cinnamon/assets
+  copy_r ${SRC_DIR}/assets/cinnamon/assets${color}/*.svg                                ${THEME_DIR}/cinnamon/assets
+  copy_r ${SRC_DIR}/assets/cinnamon/thumbnail${color}.png                               ${THEME_DIR}/cinnamon/thumbnail.png
 
   mkdir -p                                                                              ${THEME_DIR}/plank
-  cp -ur ${SRC_DIR}/other/plank/${name}${color}/*.theme                                 ${THEME_DIR}/plank
+  copy_r ${SRC_DIR}/other/plank/${name}${color}/*.theme                                 ${THEME_DIR}/plank
 }
 
 # Backup and install files related to GDM theme
@@ -170,7 +181,7 @@ install_gdm() {
     # rm -rf "$ETC_THEME_FILE" "$GS_THEME_FILE"
     # mv "$GS_THEME_FILE.bak" "$GS_THEME_FILE"
     [[ -d $SHELL_THEME_FOLDER/Mojave ]] && rm -rf $SHELL_THEME_FOLDER/Mojave
-    cp -ur "$GDM_THEME_DIR/gnome-shell" "$SHELL_THEME_FOLDER/Mojave"
+    copy_r "$GDM_THEME_DIR/gnome-shell" "$SHELL_THEME_FOLDER/Mojave"
     cd "$ETC_THEME_FOLDER"
     ln -s "$SHELL_THEME_FOLDER/Mojave/gnome-shell.css" gdm3.css
   fi

--- a/parse-sass.sh
+++ b/parse-sass.sh
@@ -1,4 +1,5 @@
 #! /usr/bin/env bash
+set -ueo pipefail
 set -o physical
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"

--- a/parse-sass.sh
+++ b/parse-sass.sh
@@ -19,6 +19,8 @@ if [ ! "$(which sassc 2> /dev/null)" ]; then
     sudo yum install sassc
   elif has_command pacman; then
     sudo pacman -S --noconfirm sassc
+  else
+    exit 1
   fi
 fi
 

--- a/parse-sass.sh
+++ b/parse-sass.sh
@@ -1,6 +1,7 @@
 #! /usr/bin/env bash
+set -o physical
 
-REPO_DIR=$(cd $(dirname $0) && pwd)
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
 # check command avalibility
 has_command() {

--- a/parse-sass.sh
+++ b/parse-sass.sh
@@ -20,6 +20,8 @@ if [ ! "$(which sassc 2> /dev/null)" ]; then
     sudo yum install sassc
   elif has_command pacman; then
     sudo pacman -S --noconfirm sassc
+  elif had_command brew; then
+    brew install sassc
   else
     exit 1
   fi

--- a/parse-sass.sh
+++ b/parse-sass.sh
@@ -5,7 +5,7 @@ REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
 # check command avalibility
 has_command() {
-  "$1" -v $1 > /dev/null 2>&1
+  "$1" -v "$1" > /dev/null 2>&1
 }
 
 if [ ! "$(which sassc 2> /dev/null)" ]; then
@@ -25,7 +25,7 @@ if [ ! "$(which sassc 2> /dev/null)" ]; then
   fi
 fi
 
-SASSC_OPT="-M -t expanded"
+SASSC_OPT=(-M -t expanded)
 
 _COLOR_VARIANTS=('-light' '-dark')
 if [ ! -z "${COLOR_VARIANTS:-}" ]; then
@@ -39,11 +39,11 @@ fi
 
 for color in "${_COLOR_VARIANTS[@]}"; do
   for trans in "${_TRANS_VARIANTS[@]}"; do
-    sassc $SASSC_OPT $REPO_DIR/src/main/gtk-3.0/gtk${color}${trans}.{scss,css}
+    sassc "${SASSC_OPT[@]}" "$REPO_DIR/src/main/gtk-3.0/gtk${color}${trans}."{scss,css}
     echo "==> Generating the gtk${color}${trans}.css..."
-    sassc $SASSC_OPT $REPO_DIR/src/main/gnome-shell/gnome-shell${color}${trans}.{scss,css}
+    sassc "${SASSC_OPT[@]}" "$REPO_DIR/src/main/gnome-shell/gnome-shell${color}${trans}."{scss,css}
     echo "==> Generating the gnome-shell${color}${trans}.css..."
-    sassc $SASSC_OPT $REPO_DIR/src/main/cinnamon/cinnamon${color}${trans}.{scss,css}
+    sassc "${SASSC_OPT[@]}" "$REPO_DIR/src/main/cinnamon/cinnamon${color}${trans}."{scss,css}
     echo "==> Generating the cinnamon${color}${trans}.css..."
   done
 done

--- a/parse-sass.sh
+++ b/parse-sass.sh
@@ -5,7 +5,7 @@ REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
 # check command avalibility
 has_command() {
-  "$1" -v "$1" > /dev/null 2>&1
+  command -v "${1}" > /dev/null 2>&1
 }
 
 if [ ! "$(which sassc 2> /dev/null)" ]; then

--- a/parse-sass.sh
+++ b/parse-sass.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 REPO_DIR=$(cd $(dirname $0) && pwd)
 

--- a/render-assets.sh
+++ b/render-assets.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 INKSCAPE="/usr/bin/inkscape"
 OPTIPNG="/usr/bin/optipng"

--- a/render-assets.sh
+++ b/render-assets.sh
@@ -1,4 +1,5 @@
 #! /usr/bin/env bash
+set -ueo pipefail
 set -o physical
 
 INKSCAPE="/usr/bin/inkscape"

--- a/render-assets.sh
+++ b/render-assets.sh
@@ -23,6 +23,8 @@ if [ ! "$(which inkscape 2> /dev/null)" ]; then
     sudo dnf install inkscape optipng
   elif has_command pacman; then
     sudo pacman -S --noconfirm inkscape optipng
+  else
+    exit 1
   fi
 fi
 

--- a/render-assets.sh
+++ b/render-assets.sh
@@ -9,7 +9,7 @@ ASRC_DIR="${REPO_DIR}/src/assets"
 
 # check command avalibility
 has_command() {
-  "$1" -v $1 > /dev/null 2>&1
+  "$1" -v "$1" > /dev/null 2>&1
 }
 
 if [ ! "$(which inkscape 2> /dev/null)" ]; then
@@ -30,19 +30,19 @@ if [ ! "$(which inkscape 2> /dev/null)" ]; then
 fi
 
 render_thumbnail() {
-  local dest=$1
-  local color=$2
+  local dest="$1"
+  local color="$2"
 
-  if [ -f $ASRC_DIR/$1/thumbnail$2.png ]; then
-    echo $ASRC_DIR/$1/thumbnail$2.png exists.
+  if [ -f "$ASRC_DIR/$1/thumbnail$2.png" ]; then
+    echo "$ASRC_DIR/$1/thumbnail$2.png exists."
   else
     echo
-    echo Rendering $ASRC_DIR/$1/thumbnail$2.png
+    echo "Rendering $ASRC_DIR/$1/thumbnail$2.png"
 
-    $INKSCAPE --export-id=thumbnail$2 \
+    "$INKSCAPE" --export-id="thumbnail$2" \
               --export-id-only \
-              --export-filename=$ASRC_DIR/$1/thumbnail$2.png $ASRC_DIR/$1/thumbnail.svg >/dev/null
-    $OPTIPNG -o7 --quiet $ASRC_DIR/$1/thumbnail$2.png
+              --export-filename="$ASRC_DIR/$1/thumbnail$2.png" "$ASRC_DIR/$1/thumbnail.svg" >/dev/null
+    "$OPTIPNG" -o7 --quiet "$ASRC_DIR/$1/thumbnail$2.png"
   fi
 }
 
@@ -53,16 +53,16 @@ for color in '-light' '-dark' ; do
 done
 
 echo Rendering gtk-2.0 assets
-cd $ASRC_DIR/gtk-2.0 && ./render-assets.sh
+cd "$ASRC_DIR/gtk-2.0" && ./render-assets.sh
 
 echo Rendering gtk-3.0 assets
-cd $ASRC_DIR/gtk-3.0/common-assets && ./render-assets.sh
-cd $ASRC_DIR/gtk-3.0/windows-assets && ./render-assets.sh && ./render-alt-assets.sh
+cd "$ASRC_DIR/gtk-3.0/common-assets" && ./render-assets.sh
+cd "$ASRC_DIR/gtk-3.0/windows-assets" && ./render-assets.sh && ./render-alt-assets.sh
 
 echo Rendering metacity-1 assets
-cd $ASRC_DIR/metacity-1 && ./render-assets.sh
+cd "$ASRC_DIR/metacity-1" && ./render-assets.sh
 
 echo Rendering xfwm4 assets
-cd $ASRC_DIR/xfwm4 && ./render-assets.sh
+cd "$ASRC_DIR/xfwm4" && ./render-assets.sh
 
 exit 0

--- a/render-assets.sh
+++ b/render-assets.sh
@@ -9,7 +9,7 @@ ASRC_DIR="${REPO_DIR}/src/assets"
 
 # check command avalibility
 has_command() {
-  "$1" -v "$1" > /dev/null 2>&1
+  command -v "${1}" > /dev/null 2>&1
 }
 
 if [ ! "$(which inkscape 2> /dev/null)" ]; then

--- a/render-assets.sh
+++ b/render-assets.sh
@@ -24,6 +24,9 @@ if [ ! "$(which inkscape 2> /dev/null)" ]; then
     sudo dnf install inkscape optipng
   elif has_command pacman; then
     sudo pacman -S --noconfirm inkscape optipng
+  elif had_command brew; then
+    brew install --cask inkscape
+    brew install optipng
   else
     exit 1
   fi

--- a/render-assets.sh
+++ b/render-assets.sh
@@ -1,10 +1,11 @@
 #! /usr/bin/env bash
+set -o physical
 
 INKSCAPE="/usr/bin/inkscape"
 OPTIPNG="/usr/bin/optipng"
 
-REPO_DIR=$(cd $(dirname $0) && pwd)
-ASRC_DIR=${REPO_DIR}/src/assets
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+ASRC_DIR="${REPO_DIR}/src/assets"
 
 # check command avalibility
 has_command() {

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 set -ueo pipefail
 #set -x
 

--- a/test.sh
+++ b/test.sh
@@ -49,91 +49,91 @@ usage() {
 }
 
 install() {
-  local dest=${1}
-  local name=${2}
-  local color=${3}
-  local opacity=${4}
-  local alt=${5}
-  local icon=${6}
+  local dest="${1}"
+  local name="${2}"
+  local color="${3}"
+  local opacity="${4}"
+  local alt="${5}"
+  local icon="${6}"
 
-  [[ ${color} == '-light' ]] && local ELSE_LIGHT=${color}
-  [[ ${color} == '-dark' ]] && local ELSE_DARK=${color}
+  [[ "${color}" == '-light' ]] && local ELSE_LIGHT="${color}"
+  [[ "${color}" == '-dark' ]] && local ELSE_DARK="${color}"
 
-  local THEME_DIR=${1}/${2}${3}${4}${5}
+  local THEME_DIR="${1}/${2}${3}${4}${5}"
 
-  [[ -d ${THEME_DIR} ]] && rm -rf ${THEME_DIR}
+  [[ -d "${THEME_DIR}" ]] && rm -rf "${THEME_DIR}"
 
   echo "Installing '${THEME_DIR}'..."
 
-  mkdir -p                                                                              ${THEME_DIR}
-  copy_r ${REPO_DIR}/COPYING                                                            ${THEME_DIR}
+  mkdir -p                                                                                  "${THEME_DIR}"
+  copy_r "${REPO_DIR}/COPYING"                                                              "${THEME_DIR}"
 
-  echo "[Desktop Entry]" >>                                                             ${THEME_DIR}/index.theme
-  echo "Type=X-GNOME-Metatheme" >>                                                      ${THEME_DIR}/index.theme
-  echo "Name=${name}${color}${opacity}" >>                                              ${THEME_DIR}/index.theme
-  echo "Comment=An Stylish Gtk+ theme based on Elegant Design" >>                       ${THEME_DIR}/index.theme
-  echo "Encoding=UTF-8" >>                                                              ${THEME_DIR}/index.theme
-  echo "" >>                                                                            ${THEME_DIR}/index.theme
-  echo "[X-GNOME-Metatheme]" >>                                                         ${THEME_DIR}/index.theme
-  echo "GtkTheme=${name}${color}${opacity}" >>                                          ${THEME_DIR}/index.theme
-  echo "MetacityTheme=${name}${color}${opacity}" >>                                     ${THEME_DIR}/index.theme
-  echo "IconTheme=Adwaita" >>                                                           ${THEME_DIR}/index.theme
-  echo "CursorTheme=Adwaita" >>                                                         ${THEME_DIR}/index.theme
-  echo "ButtonLayout=close,minimize,maximize:menu" >>                                   ${THEME_DIR}/index.theme
+  echo "[Desktop Entry]" >>                                                                 "${THEME_DIR}/index.theme"
+  echo "Type=X-GNOME-Metatheme" >>                                                          "${THEME_DIR}/index.theme"
+  echo "Name=${name}${color}${opacity}" >>                                                  "${THEME_DIR}/index.theme"
+  echo "Comment=An Stylish Gtk+ theme based on Elegant Design" >>                           "${THEME_DIR}/index.theme"
+  echo "Encoding=UTF-8" >>                                                                  "${THEME_DIR}/index.theme"
+  echo "" >>                                                                                "${THEME_DIR}/index.theme"
+  echo "[X-GNOME-Metatheme]" >>                                                             "${THEME_DIR}/index.theme"
+  echo "GtkTheme=${name}${color}${opacity}" >>                                              "${THEME_DIR}/index.theme"
+  echo "MetacityTheme=${name}${color}${opacity}" >>                                         "${THEME_DIR}/index.theme"
+  echo "IconTheme=Adwaita" >>                                                               "${THEME_DIR}/index.theme"
+  echo "CursorTheme=Adwaita" >>                                                             "${THEME_DIR}/index.theme"
+  echo "ButtonLayout=close,minimize,maximize:menu" >>                                       "${THEME_DIR}/index.theme"
 
-  mkdir -p                                                                              ${THEME_DIR}/gnome-shell
-  copy_r ${SRC_DIR}/main/gnome-shell/gnome-shell${color}${opacity}.css                  ${THEME_DIR}/gnome-shell/gnome-shell.css
-  copy_r ${SRC_DIR}/assets/gnome-shell/common-assets                                    ${THEME_DIR}/gnome-shell/assets
-  copy_r ${SRC_DIR}/assets/gnome-shell/assets${color}/*.svg                             ${THEME_DIR}/gnome-shell/assets
-  copy_r ${SRC_DIR}/assets/gnome-shell/assets${color}/background.png                    ${THEME_DIR}/gnome-shell/assets
-  copy_r ${SRC_DIR}/assets/gnome-shell/assets${color}/activities/activities${icon}.svg  ${THEME_DIR}/gnome-shell/assets/activities.svg
-  cd ${THEME_DIR}/gnome-shell
+  mkdir -p                                                                                  "${THEME_DIR}/gnome-shell"
+  copy_r "${SRC_DIR}/main/gnome-shell/gnome-shell${color}${opacity}.css"                    "${THEME_DIR}/gnome-shell/gnome-shell.css"
+  copy_r "${SRC_DIR}/assets/gnome-shell/common-assets"                                      "${THEME_DIR}/gnome-shell/assets"
+  copy_r "${SRC_DIR}/assets/gnome-shell/assets${color}/"*'.svg'                             "${THEME_DIR}/gnome-shell/assets"
+  copy_r "${SRC_DIR}/assets/gnome-shell/assets${color}/background.png"                      "${THEME_DIR}/gnome-shell/assets"
+  copy_r "${SRC_DIR}/assets/gnome-shell/assets${color}/activities/activities${icon}.svg"    "${THEME_DIR}/gnome-shell/assets/activities.svg"
+  cd "${THEME_DIR}/gnome-shell"
   ln -s assets/no-events.svg no-events.svg
   ln -s assets/process-working.svg process-working.svg
   ln -s assets/no-notifications.svg no-notifications.svg
 
-  mkdir -p                                                                              ${THEME_DIR}/gtk-2.0
-  copy_r ${SRC_DIR}/main/gtk-2.0/gtkrc${color}                                          ${THEME_DIR}/gtk-2.0/gtkrc
-  copy_r ${SRC_DIR}/main/gtk-2.0/menubar-toolbar${color}.rc                             ${THEME_DIR}/gtk-2.0/menubar-toolbar.rc
-  copy_r ${SRC_DIR}/main/gtk-2.0/common/*.rc                                            ${THEME_DIR}/gtk-2.0
-  copy_r ${SRC_DIR}/assets/gtk-2.0/assets${color}                                       ${THEME_DIR}/gtk-2.0/assets
+  mkdir -p                                                                                  "${THEME_DIR}/gtk-2.0"
+  copy_r "${SRC_DIR}/main/gtk-2.0/gtkrc${color}"                                            "${THEME_DIR}/gtk-2.0/gtkrc"
+  copy_r "${SRC_DIR}/main/gtk-2.0/menubar-toolbar${color}.rc"                               "${THEME_DIR}/gtk-2.0/menubar-toolbar.rc"
+  copy_r "${SRC_DIR}/main/gtk-2.0/common/"*'.rc'                                            "${THEME_DIR}/gtk-2.0"
+  copy_r "${SRC_DIR}/assets/gtk-2.0/assets${color}"                                         "${THEME_DIR}/gtk-2.0/assets"
 
-  mkdir -p                                                                              ${THEME_DIR}/gtk-3.0
-  copy_r ${SRC_DIR}/assets/gtk-3.0/common-assets/assets                                 ${THEME_DIR}/gtk-3.0
-  copy_r ${SRC_DIR}/assets/gtk-3.0/windows-assets/titlebutton${alt}                     ${THEME_DIR}/gtk-3.0/windows-assets
-  copy_r ${SRC_DIR}/assets/gtk-3.0/thumbnail${color}.png                                ${THEME_DIR}/gtk-3.0/thumbnail.png
-  copy_r ${SRC_DIR}/main/gtk-3.0/gtk-dark${opacity}.css                                 ${THEME_DIR}/gtk-3.0/gtk-dark.css
+  mkdir -p                                                                                  "${THEME_DIR}/gtk-3.0"
+  copy_r "${SRC_DIR}/assets/gtk-3.0/common-assets/assets"                                   "${THEME_DIR}/gtk-3.0"
+  copy_r "${SRC_DIR}/assets/gtk-3.0/windows-assets/titlebutton${alt}"                       "${THEME_DIR}/gtk-3.0/windows-assets"
+  copy_r "${SRC_DIR}/assets/gtk-3.0/thumbnail${color}.png"                                  "${THEME_DIR}/gtk-3.0/thumbnail.png"
+  copy_r "${SRC_DIR}/main/gtk-3.0/gtk-dark${opacity}.css"                                   "${THEME_DIR}/gtk-3.0/gtk-dark.css"
 
-  if [[ ${color} == '-light' ]]; then
-    copy_r ${SRC_DIR}/main/gtk-3.0/gtk-light${opacity}.css                              ${THEME_DIR}/gtk-3.0/gtk.css
+  if [[ "${color}" == '-light' ]]; then
+    copy_r "${SRC_DIR}/main/gtk-3.0/gtk-light${opacity}.css"                                "${THEME_DIR}/gtk-3.0/gtk.css"
   else
-    copy_r ${SRC_DIR}/main/gtk-3.0/gtk-dark${opacity}.css                               ${THEME_DIR}/gtk-3.0/gtk.css
+    copy_r "${SRC_DIR}/main/gtk-3.0/gtk-dark${opacity}.css"                                 "${THEME_DIR}/gtk-3.0/gtk.css"
   fi
 
-  glib-compile-resources --sourcedir=${THEME_DIR}/gtk-3.0 --target=${THEME_DIR}/gtk-3.0/gtk.gresource ${SRC_DIR}/main/gtk-3.0/gtk.gresource.xml
-  rm -rf ${THEME_DIR}/gtk-3.0/{assets,windows-assets,gtk.css,gtk-dark.css}
-  echo '@import url("resource:///org/gnome/Mojave-theme/gtk.css");' >>                  ${THEME_DIR}/gtk-3.0/gtk.css
-  echo '@import url("resource:///org/gnome/Mojave-theme/gtk-dark.css");' >>             ${THEME_DIR}/gtk-3.0/gtk-dark.css
+  glib-compile-resources --sourcedir="${THEME_DIR}/gtk-3.0" --target="${THEME_DIR}/gtk-3.0/gtk.gresource" "${SRC_DIR}/main/gtk-3.0/gtk.gresource.xml"
+  rm -rf "${THEME_DIR}/gtk-3.0/{assets,windows-assets,gtk.css,gtk-dark.css}"
+  echo '@import url("resource:///org/gnome/Mojave-theme/gtk.css");' >>                      "${THEME_DIR}/gtk-3.0/gtk.css"
+  echo '@import url("resource:///org/gnome/Mojave-theme/gtk-dark.css");' >>                 "${THEME_DIR}/gtk-3.0/gtk-dark.css"
 
-  mkdir -p                                                                              ${THEME_DIR}/metacity-1
-  copy_r ${SRC_DIR}/main/metacity-1/metacity-theme${color}.xml                          ${THEME_DIR}/metacity-1/metacity-theme-1.xml
-  copy_r ${SRC_DIR}/main/metacity-1/metacity-theme-3.xml                                ${THEME_DIR}/metacity-1
-  copy_r ${SRC_DIR}/assets/metacity-1/assets/*.png                                      ${THEME_DIR}/metacity-1
-  copy_r ${SRC_DIR}/assets/metacity-1/thumbnail${color}.png                             ${THEME_DIR}/metacity-1/thumbnail.png
-  cd ${THEME_DIR}/metacity-1 && ln -s metacity-theme-1.xml metacity-theme-2.xml
+  mkdir -p                                                                                  "${THEME_DIR}/metacity-1"
+  copy_r "${SRC_DIR}/main/metacity-1/metacity-theme${color}.xml"                            "${THEME_DIR}/metacity-1/metacity-theme-1.xml"
+  copy_r "${SRC_DIR}/main/metacity-1/metacity-theme-3.xml"                                  "${THEME_DIR}/metacity-1"
+  copy_r "${SRC_DIR}/assets/metacity-1/assets/"*'.png'                                      "${THEME_DIR}/metacity-1"
+  copy_r "${SRC_DIR}/assets/metacity-1/thumbnail${color}.png"                               "${THEME_DIR}/metacity-1/thumbnail.png"
+  cd "${THEME_DIR}/metacity-1" && ln -s metacity-theme-1.xml metacity-theme-2.xml
 
-  mkdir -p                                                                              ${THEME_DIR}/xfwm4
-  copy_r ${SRC_DIR}/assets/xfwm4/assets${color}/*.png                                   ${THEME_DIR}/xfwm4
-  copy_r ${SRC_DIR}/main/xfwm4/themerc${color}                                          ${THEME_DIR}/xfwm4/themerc
+  mkdir -p                                                                                  "${THEME_DIR}/xfwm4"
+  copy_r "${SRC_DIR}/assets/xfwm4/assets${color}/"*'.png'                                   "${THEME_DIR}/xfwm4"
+  copy_r "${SRC_DIR}/main/xfwm4/themerc${color}"                                            "${THEME_DIR}/xfwm4/themerc"
 
-  mkdir -p                                                                              ${THEME_DIR}/cinnamon
-  copy_r ${SRC_DIR}/main/cinnamon/cinnamon${color}${opacity}.css                        ${THEME_DIR}/cinnamon/cinnamon.css
-  copy_r ${SRC_DIR}/assets/cinnamon/common-assets                                       ${THEME_DIR}/cinnamon/assets
-  copy_r ${SRC_DIR}/assets/cinnamon/assets${color}/*.svg                                ${THEME_DIR}/cinnamon/assets
-  copy_r ${SRC_DIR}/assets/cinnamon/thumbnail${color}.png                               ${THEME_DIR}/cinnamon/thumbnail.png
+  mkdir -p                                                                                  "${THEME_DIR}/cinnamon"
+  copy_r "${SRC_DIR}/main/cinnamon/cinnamon${color}${opacity}.css"                          "${THEME_DIR}/cinnamon/cinnamon.css"
+  copy_r "${SRC_DIR}/assets/cinnamon/common-assets"                                         "${THEME_DIR}/cinnamon/assets"
+  copy_r "${SRC_DIR}/assets/cinnamon/assets${color}/"*.'svg'                                "${THEME_DIR}/cinnamon/assets"
+  copy_r "${SRC_DIR}/assets/cinnamon/thumbnail${color}.png"                                 "${THEME_DIR}/cinnamon/thumbnail.png"
 
-  mkdir -p                                                                              ${THEME_DIR}/plank
-  copy_r ${SRC_DIR}/other/plank/${name}${color}/*.theme                                 ${THEME_DIR}/plank
+  mkdir -p                                                                                  "${THEME_DIR}/plank"
+  copy_r "${SRC_DIR}/other/plank/${name}${color}/"*'.theme'                                 "${THEME_DIR}/plank"
 }
 
 # Backup and install files related to GDM theme
@@ -179,7 +179,7 @@ install_gdm() {
     cp -an "$ETC_THEME_FILE" "$ETC_THEME_FILE.bak"
     # rm -rf "$ETC_THEME_FILE" "$GS_THEME_FILE"
     # mv "$GS_THEME_FILE.bak" "$GS_THEME_FILE"
-    [[ -d $SHELL_THEME_FOLDER/Mojave ]] && rm -rf $SHELL_THEME_FOLDER/Mojave
+    [[ -d "$SHELL_THEME_FOLDER/Mojave" ]] && rm -rf "$SHELL_THEME_FOLDER/Mojave"
     copy_r "$GDM_THEME_DIR/gnome-shell" "$SHELL_THEME_FOLDER/Mojave"
     cd "$ETC_THEME_FOLDER"
     ln -s "$SHELL_THEME_FOLDER/Mojave/gnome-shell.css" gdm3.css
@@ -209,7 +209,7 @@ revert_gdm() {
     echo "reverting Ubuntu gnome-shell theme..."
     rm -rf "$ETC_THEME_FILE"
     mv "$ETC_THEME_FILE.bak" "$ETC_THEME_FILE"
-    [[ -d $SHELL_THEME_FOLDER/Mojave ]] && rm -rf $SHELL_THEME_FOLDER/Mojave
+    [[ -d "$SHELL_THEME_FOLDER/Mojave" ]] && rm -rf "$SHELL_THEME_FOLDER/Mojave"
   fi
 }
 

--- a/test.sh
+++ b/test.sh
@@ -1,9 +1,10 @@
 #! /usr/bin/env bash
 set -ueo pipefail
+set -o physical
 #set -x
 
-REPO_DIR=$(cd $(dirname $0) && pwd)
-SRC_DIR=${REPO_DIR}/src
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+SRC_DIR="${REPO_DIR}/src"
 
 ROOT_UID=0
 DEST_DIR=

--- a/test.sh
+++ b/test.sh
@@ -21,6 +21,17 @@ OPACITY_VARIANTS=('' '-solid')
 ALT_VARIANTS=('' '-alt')
 ICON_VARIANTS=('' '-normal' '-gnome' '-ubuntu' '-arch' '-manjaro' '-fedora' '-debian' '-void')
 
+copy_r() {
+	case "$(uname -s)" in
+		'FreeBSD'|'Darwin')
+			cp -r "${@}"
+			;;
+		*)
+			cp -ur "${@}"
+			;;
+	esac
+}
+
 usage() {
   printf "%s\n" "Usage: $0 [OPTIONS...]"
   printf "\n%s\n" "OPTIONS:"
@@ -54,7 +65,7 @@ install() {
   echo "Installing '${THEME_DIR}'..."
 
   mkdir -p                                                                              ${THEME_DIR}
-  cp -ur ${REPO_DIR}/COPYING                                                            ${THEME_DIR}
+  copy_r ${REPO_DIR}/COPYING                                                            ${THEME_DIR}
 
   echo "[Desktop Entry]" >>                                                             ${THEME_DIR}/index.theme
   echo "Type=X-GNOME-Metatheme" >>                                                      ${THEME_DIR}/index.theme
@@ -70,32 +81,32 @@ install() {
   echo "ButtonLayout=close,minimize,maximize:menu" >>                                   ${THEME_DIR}/index.theme
 
   mkdir -p                                                                              ${THEME_DIR}/gnome-shell
-  cp -ur ${SRC_DIR}/main/gnome-shell/gnome-shell${color}${opacity}.css                  ${THEME_DIR}/gnome-shell/gnome-shell.css
-  cp -ur ${SRC_DIR}/assets/gnome-shell/common-assets                                    ${THEME_DIR}/gnome-shell/assets
-  cp -ur ${SRC_DIR}/assets/gnome-shell/assets${color}/*.svg                             ${THEME_DIR}/gnome-shell/assets
-  cp -ur ${SRC_DIR}/assets/gnome-shell/assets${color}/background.png                    ${THEME_DIR}/gnome-shell/assets
-  cp -ur ${SRC_DIR}/assets/gnome-shell/assets${color}/activities/activities${icon}.svg  ${THEME_DIR}/gnome-shell/assets/activities.svg
+  copy_r ${SRC_DIR}/main/gnome-shell/gnome-shell${color}${opacity}.css                  ${THEME_DIR}/gnome-shell/gnome-shell.css
+  copy_r ${SRC_DIR}/assets/gnome-shell/common-assets                                    ${THEME_DIR}/gnome-shell/assets
+  copy_r ${SRC_DIR}/assets/gnome-shell/assets${color}/*.svg                             ${THEME_DIR}/gnome-shell/assets
+  copy_r ${SRC_DIR}/assets/gnome-shell/assets${color}/background.png                    ${THEME_DIR}/gnome-shell/assets
+  copy_r ${SRC_DIR}/assets/gnome-shell/assets${color}/activities/activities${icon}.svg  ${THEME_DIR}/gnome-shell/assets/activities.svg
   cd ${THEME_DIR}/gnome-shell
   ln -s assets/no-events.svg no-events.svg
   ln -s assets/process-working.svg process-working.svg
   ln -s assets/no-notifications.svg no-notifications.svg
 
   mkdir -p                                                                              ${THEME_DIR}/gtk-2.0
-  cp -ur ${SRC_DIR}/main/gtk-2.0/gtkrc${color}                                          ${THEME_DIR}/gtk-2.0/gtkrc
-  cp -ur ${SRC_DIR}/main/gtk-2.0/menubar-toolbar${color}.rc                             ${THEME_DIR}/gtk-2.0/menubar-toolbar.rc
-  cp -ur ${SRC_DIR}/main/gtk-2.0/common/*.rc                                            ${THEME_DIR}/gtk-2.0
-  cp -ur ${SRC_DIR}/assets/gtk-2.0/assets${color}                                       ${THEME_DIR}/gtk-2.0/assets
+  copy_r ${SRC_DIR}/main/gtk-2.0/gtkrc${color}                                          ${THEME_DIR}/gtk-2.0/gtkrc
+  copy_r ${SRC_DIR}/main/gtk-2.0/menubar-toolbar${color}.rc                             ${THEME_DIR}/gtk-2.0/menubar-toolbar.rc
+  copy_r ${SRC_DIR}/main/gtk-2.0/common/*.rc                                            ${THEME_DIR}/gtk-2.0
+  copy_r ${SRC_DIR}/assets/gtk-2.0/assets${color}                                       ${THEME_DIR}/gtk-2.0/assets
 
   mkdir -p                                                                              ${THEME_DIR}/gtk-3.0
-  cp -ur ${SRC_DIR}/assets/gtk-3.0/common-assets/assets                                 ${THEME_DIR}/gtk-3.0
-  cp -ur ${SRC_DIR}/assets/gtk-3.0/windows-assets/titlebutton${alt}                     ${THEME_DIR}/gtk-3.0/windows-assets
-  cp -ur ${SRC_DIR}/assets/gtk-3.0/thumbnail${color}.png                                ${THEME_DIR}/gtk-3.0/thumbnail.png
-  cp -ur ${SRC_DIR}/main/gtk-3.0/gtk-dark${opacity}.css                                 ${THEME_DIR}/gtk-3.0/gtk-dark.css
+  copy_r ${SRC_DIR}/assets/gtk-3.0/common-assets/assets                                 ${THEME_DIR}/gtk-3.0
+  copy_r ${SRC_DIR}/assets/gtk-3.0/windows-assets/titlebutton${alt}                     ${THEME_DIR}/gtk-3.0/windows-assets
+  copy_r ${SRC_DIR}/assets/gtk-3.0/thumbnail${color}.png                                ${THEME_DIR}/gtk-3.0/thumbnail.png
+  copy_r ${SRC_DIR}/main/gtk-3.0/gtk-dark${opacity}.css                                 ${THEME_DIR}/gtk-3.0/gtk-dark.css
 
   if [[ ${color} == '-light' ]]; then
-    cp -ur ${SRC_DIR}/main/gtk-3.0/gtk-light${opacity}.css                              ${THEME_DIR}/gtk-3.0/gtk.css
+    copy_r ${SRC_DIR}/main/gtk-3.0/gtk-light${opacity}.css                              ${THEME_DIR}/gtk-3.0/gtk.css
   else
-    cp -ur ${SRC_DIR}/main/gtk-3.0/gtk-dark${opacity}.css                               ${THEME_DIR}/gtk-3.0/gtk.css
+    copy_r ${SRC_DIR}/main/gtk-3.0/gtk-dark${opacity}.css                               ${THEME_DIR}/gtk-3.0/gtk.css
   fi
 
   glib-compile-resources --sourcedir=${THEME_DIR}/gtk-3.0 --target=${THEME_DIR}/gtk-3.0/gtk.gresource ${SRC_DIR}/main/gtk-3.0/gtk.gresource.xml
@@ -104,24 +115,24 @@ install() {
   echo '@import url("resource:///org/gnome/Mojave-theme/gtk-dark.css");' >>             ${THEME_DIR}/gtk-3.0/gtk-dark.css
 
   mkdir -p                                                                              ${THEME_DIR}/metacity-1
-  cp -ur ${SRC_DIR}/main/metacity-1/metacity-theme${color}.xml                          ${THEME_DIR}/metacity-1/metacity-theme-1.xml
-  cp -ur ${SRC_DIR}/main/metacity-1/metacity-theme-3.xml                                ${THEME_DIR}/metacity-1
-  cp -ur ${SRC_DIR}/assets/metacity-1/assets/*.png                                      ${THEME_DIR}/metacity-1
-  cp -ur ${SRC_DIR}/assets/metacity-1/thumbnail${color}.png                             ${THEME_DIR}/metacity-1/thumbnail.png
+  copy_r ${SRC_DIR}/main/metacity-1/metacity-theme${color}.xml                          ${THEME_DIR}/metacity-1/metacity-theme-1.xml
+  copy_r ${SRC_DIR}/main/metacity-1/metacity-theme-3.xml                                ${THEME_DIR}/metacity-1
+  copy_r ${SRC_DIR}/assets/metacity-1/assets/*.png                                      ${THEME_DIR}/metacity-1
+  copy_r ${SRC_DIR}/assets/metacity-1/thumbnail${color}.png                             ${THEME_DIR}/metacity-1/thumbnail.png
   cd ${THEME_DIR}/metacity-1 && ln -s metacity-theme-1.xml metacity-theme-2.xml
 
   mkdir -p                                                                              ${THEME_DIR}/xfwm4
-  cp -ur ${SRC_DIR}/assets/xfwm4/assets${color}/*.png                                   ${THEME_DIR}/xfwm4
-  cp -ur ${SRC_DIR}/main/xfwm4/themerc${color}                                          ${THEME_DIR}/xfwm4/themerc
+  copy_r ${SRC_DIR}/assets/xfwm4/assets${color}/*.png                                   ${THEME_DIR}/xfwm4
+  copy_r ${SRC_DIR}/main/xfwm4/themerc${color}                                          ${THEME_DIR}/xfwm4/themerc
 
   mkdir -p                                                                              ${THEME_DIR}/cinnamon
-  cp -ur ${SRC_DIR}/main/cinnamon/cinnamon${color}${opacity}.css                        ${THEME_DIR}/cinnamon/cinnamon.css
-  cp -ur ${SRC_DIR}/assets/cinnamon/common-assets                                       ${THEME_DIR}/cinnamon/assets
-  cp -ur ${SRC_DIR}/assets/cinnamon/assets${color}/*.svg                                ${THEME_DIR}/cinnamon/assets
-  cp -ur ${SRC_DIR}/assets/cinnamon/thumbnail${color}.png                               ${THEME_DIR}/cinnamon/thumbnail.png
+  copy_r ${SRC_DIR}/main/cinnamon/cinnamon${color}${opacity}.css                        ${THEME_DIR}/cinnamon/cinnamon.css
+  copy_r ${SRC_DIR}/assets/cinnamon/common-assets                                       ${THEME_DIR}/cinnamon/assets
+  copy_r ${SRC_DIR}/assets/cinnamon/assets${color}/*.svg                                ${THEME_DIR}/cinnamon/assets
+  copy_r ${SRC_DIR}/assets/cinnamon/thumbnail${color}.png                               ${THEME_DIR}/cinnamon/thumbnail.png
 
   mkdir -p                                                                              ${THEME_DIR}/plank
-  cp -ur ${SRC_DIR}/other/plank/${name}${color}/*.theme                                 ${THEME_DIR}/plank
+  copy_r ${SRC_DIR}/other/plank/${name}${color}/*.theme                                 ${THEME_DIR}/plank
 }
 
 # Backup and install files related to GDM theme
@@ -168,7 +179,7 @@ install_gdm() {
     # rm -rf "$ETC_THEME_FILE" "$GS_THEME_FILE"
     # mv "$GS_THEME_FILE.bak" "$GS_THEME_FILE"
     [[ -d $SHELL_THEME_FOLDER/Mojave ]] && rm -rf $SHELL_THEME_FOLDER/Mojave
-    cp -ur "$GDM_THEME_DIR/gnome-shell" "$SHELL_THEME_FOLDER/Mojave"
+    copy_r "$GDM_THEME_DIR/gnome-shell" "$SHELL_THEME_FOLDER/Mojave"
     cd "$ETC_THEME_FOLDER"
     ln -s "$SHELL_THEME_FOLDER/Mojave/gnome-shell.css" gdm3.css
   fi


### PR DESCRIPTION
Most important things are:

- fix installation on macOS (macOS does not support `cp -u`)
- fix relative path resolution (install relatively to current directory, not relatively to some project subdirectory)
- abort properly on missing tools (do not try to use known missing tools)

Also:

- abort properly on errors (only half of the scripts was doing it)
- secure many strings using proper quotes
- use more portable shebang
- properly test for command availability using `command` shell builtin
- better way to get script directory
- install missing tools with `brew` on macOS

Your theme is useful to render GTK2 apps properly on macOS:

[![NetRadiant on macOS](https://dl.illwieckz.net/b/netradiant/improvements/macos/20201223-043449-000.netradiant-macos.png)](https://dl.illwieckz.net/b/netradiant/improvements/macos/20201223-043449-000.netradiant-macos.png)

[![NetRadiant on macOS](https://dl.illwieckz.net/b/netradiant/improvements/macos/20201223-115554-000.netradiant-macos.png)](https://dl.illwieckz.net/b/netradiant/improvements/macos/20201223-115554-000.netradiant-macos.png)

Which is far better than the default theme:

[![NetRadiant on macOS](https://dl.illwieckz.net/b/netradiant/improvements/macos/20201223-135554-000.netradiant-macos.png)](https://dl.illwieckz.net/b/netradiant/improvements/macos/20201223-135554-000.netradiant-macos.png)

So it's better if your macOS-like theme can be installed on macOS. =)