### PR TITLE
Fix bg color for popup menu (light themes)

### DIFF
--- a/src/main/gnome-shell/shell-40-0/gnome-shell-dark-blue.css
+++ b/src/main/gnome-shell/shell-40-0/gnome-shell-dark-blue.css
@@ -2527,6 +2527,7 @@ StEntry StLabel.hint-text, .popup-menu .search-entry StLabel.hint-text {
 .popup-menu .popup-menu-content {
   padding: 10px 0;
   font-weight: normal;
+  background-color: rgba(42, 42, 42, 0.85);
 }
 
 .popup-menu .popup-menu-item {

--- a/src/main/gnome-shell/shell-40-0/gnome-shell-dark-green.css
+++ b/src/main/gnome-shell/shell-40-0/gnome-shell-dark-green.css
@@ -2527,6 +2527,7 @@ StEntry StLabel.hint-text, .popup-menu .search-entry StLabel.hint-text {
 .popup-menu .popup-menu-content {
   padding: 10px 0;
   font-weight: normal;
+  background-color: rgba(42, 42, 42, 0.85);
 }
 
 .popup-menu .popup-menu-item {

--- a/src/main/gnome-shell/shell-40-0/gnome-shell-dark-grey.css
+++ b/src/main/gnome-shell/shell-40-0/gnome-shell-dark-grey.css
@@ -2527,6 +2527,7 @@ StEntry StLabel.hint-text, .popup-menu .search-entry StLabel.hint-text {
 .popup-menu .popup-menu-content {
   padding: 10px 0;
   font-weight: normal;
+  background-color: rgba(42, 42, 42, 0.85);
 }
 
 .popup-menu .popup-menu-item {

--- a/src/main/gnome-shell/shell-40-0/gnome-shell-dark-orange.css
+++ b/src/main/gnome-shell/shell-40-0/gnome-shell-dark-orange.css
@@ -2527,6 +2527,7 @@ StEntry StLabel.hint-text, .popup-menu .search-entry StLabel.hint-text {
 .popup-menu .popup-menu-content {
   padding: 10px 0;
   font-weight: normal;
+  background-color: rgba(42, 42, 42, 0.85);
 }
 
 .popup-menu .popup-menu-item {

--- a/src/main/gnome-shell/shell-40-0/gnome-shell-dark-pink.css
+++ b/src/main/gnome-shell/shell-40-0/gnome-shell-dark-pink.css
@@ -2527,6 +2527,7 @@ StEntry StLabel.hint-text, .popup-menu .search-entry StLabel.hint-text {
 .popup-menu .popup-menu-content {
   padding: 10px 0;
   font-weight: normal;
+  background-color: rgba(42, 42, 42, 0.85);
 }
 
 .popup-menu .popup-menu-item {

--- a/src/main/gnome-shell/shell-40-0/gnome-shell-dark-purple.css
+++ b/src/main/gnome-shell/shell-40-0/gnome-shell-dark-purple.css
@@ -2527,6 +2527,7 @@ StEntry StLabel.hint-text, .popup-menu .search-entry StLabel.hint-text {
 .popup-menu .popup-menu-content {
   padding: 10px 0;
   font-weight: normal;
+  background-color: rgba(42, 42, 42, 0.85);
 }
 
 .popup-menu .popup-menu-item {

--- a/src/main/gnome-shell/shell-40-0/gnome-shell-dark-red.css
+++ b/src/main/gnome-shell/shell-40-0/gnome-shell-dark-red.css
@@ -2527,6 +2527,7 @@ StEntry StLabel.hint-text, .popup-menu .search-entry StLabel.hint-text {
 .popup-menu .popup-menu-content {
   padding: 10px 0;
   font-weight: normal;
+  background-color: rgba(42, 42, 42, 0.85);
 }
 
 .popup-menu .popup-menu-item {

--- a/src/main/gnome-shell/shell-40-0/gnome-shell-dark-solid-blue.css
+++ b/src/main/gnome-shell/shell-40-0/gnome-shell-dark-solid-blue.css
@@ -2527,6 +2527,7 @@ StEntry StLabel.hint-text, .popup-menu .search-entry StLabel.hint-text {
 .popup-menu .popup-menu-content {
   padding: 10px 0;
   font-weight: normal;
+  background-color: #2a2a2a;
 }
 
 .popup-menu .popup-menu-item {

--- a/src/main/gnome-shell/shell-40-0/gnome-shell-dark-solid-green.css
+++ b/src/main/gnome-shell/shell-40-0/gnome-shell-dark-solid-green.css
@@ -2527,6 +2527,7 @@ StEntry StLabel.hint-text, .popup-menu .search-entry StLabel.hint-text {
 .popup-menu .popup-menu-content {
   padding: 10px 0;
   font-weight: normal;
+  background-color: #2a2a2a;
 }
 
 .popup-menu .popup-menu-item {

--- a/src/main/gnome-shell/shell-40-0/gnome-shell-dark-solid-grey.css
+++ b/src/main/gnome-shell/shell-40-0/gnome-shell-dark-solid-grey.css
@@ -2527,6 +2527,7 @@ StEntry StLabel.hint-text, .popup-menu .search-entry StLabel.hint-text {
 .popup-menu .popup-menu-content {
   padding: 10px 0;
   font-weight: normal;
+  background-color: #2a2a2a;
 }
 
 .popup-menu .popup-menu-item {

--- a/src/main/gnome-shell/shell-40-0/gnome-shell-dark-solid-orange.css
+++ b/src/main/gnome-shell/shell-40-0/gnome-shell-dark-solid-orange.css
@@ -2527,6 +2527,7 @@ StEntry StLabel.hint-text, .popup-menu .search-entry StLabel.hint-text {
 .popup-menu .popup-menu-content {
   padding: 10px 0;
   font-weight: normal;
+  background-color: #2a2a2a;
 }
 
 .popup-menu .popup-menu-item {

--- a/src/main/gnome-shell/shell-40-0/gnome-shell-dark-solid-pink.css
+++ b/src/main/gnome-shell/shell-40-0/gnome-shell-dark-solid-pink.css
@@ -2527,6 +2527,7 @@ StEntry StLabel.hint-text, .popup-menu .search-entry StLabel.hint-text {
 .popup-menu .popup-menu-content {
   padding: 10px 0;
   font-weight: normal;
+  background-color: #2a2a2a;
 }
 
 .popup-menu .popup-menu-item {

--- a/src/main/gnome-shell/shell-40-0/gnome-shell-dark-solid-purple.css
+++ b/src/main/gnome-shell/shell-40-0/gnome-shell-dark-solid-purple.css
@@ -2527,6 +2527,7 @@ StEntry StLabel.hint-text, .popup-menu .search-entry StLabel.hint-text {
 .popup-menu .popup-menu-content {
   padding: 10px 0;
   font-weight: normal;
+  background-color: #2a2a2a;
 }
 
 .popup-menu .popup-menu-item {

--- a/src/main/gnome-shell/shell-40-0/gnome-shell-dark-solid-red.css
+++ b/src/main/gnome-shell/shell-40-0/gnome-shell-dark-solid-red.css
@@ -2527,6 +2527,7 @@ StEntry StLabel.hint-text, .popup-menu .search-entry StLabel.hint-text {
 .popup-menu .popup-menu-content {
   padding: 10px 0;
   font-weight: normal;
+  background-color: #2a2a2a;
 }
 
 .popup-menu .popup-menu-item {

--- a/src/main/gnome-shell/shell-40-0/gnome-shell-dark-solid-yellow.css
+++ b/src/main/gnome-shell/shell-40-0/gnome-shell-dark-solid-yellow.css
@@ -2527,6 +2527,7 @@ StEntry StLabel.hint-text, .popup-menu .search-entry StLabel.hint-text {
 .popup-menu .popup-menu-content {
   padding: 10px 0;
   font-weight: normal;
+  background-color: #2a2a2a;
 }
 
 .popup-menu .popup-menu-item {

--- a/src/main/gnome-shell/shell-40-0/gnome-shell-dark-solid.css
+++ b/src/main/gnome-shell/shell-40-0/gnome-shell-dark-solid.css
@@ -2527,6 +2527,7 @@ StEntry StLabel.hint-text, .popup-menu .search-entry StLabel.hint-text {
 .popup-menu .popup-menu-content {
   padding: 10px 0;
   font-weight: normal;
+  background-color: #2a2a2a;
 }
 
 .popup-menu .popup-menu-item {

--- a/src/main/gnome-shell/shell-40-0/gnome-shell-dark-yellow.css
+++ b/src/main/gnome-shell/shell-40-0/gnome-shell-dark-yellow.css
@@ -2527,6 +2527,7 @@ StEntry StLabel.hint-text, .popup-menu .search-entry StLabel.hint-text {
 .popup-menu .popup-menu-content {
   padding: 10px 0;
   font-weight: normal;
+  background-color: rgba(42, 42, 42, 0.85);
 }
 
 .popup-menu .popup-menu-item {

--- a/src/main/gnome-shell/shell-40-0/gnome-shell-dark.css
+++ b/src/main/gnome-shell/shell-40-0/gnome-shell-dark.css
@@ -2527,6 +2527,7 @@ StEntry StLabel.hint-text, .popup-menu .search-entry StLabel.hint-text {
 .popup-menu .popup-menu-content {
   padding: 10px 0;
   font-weight: normal;
+  background-color: rgba(42, 42, 42, 0.85);
 }
 
 .popup-menu .popup-menu-item {

--- a/src/main/gnome-shell/shell-40-0/gnome-shell-light-blue.css
+++ b/src/main/gnome-shell/shell-40-0/gnome-shell-light-blue.css
@@ -2531,6 +2531,7 @@ StEntry StLabel.hint-text, .popup-menu .search-entry StLabel.hint-text {
 .popup-menu .popup-menu-content {
   padding: 10px 0;
   font-weight: normal;
+  background-color: rgba(241, 241, 241, 0.85);
 }
 
 .popup-menu .popup-menu-item {

--- a/src/main/gnome-shell/shell-40-0/gnome-shell-light-green.css
+++ b/src/main/gnome-shell/shell-40-0/gnome-shell-light-green.css
@@ -2531,6 +2531,7 @@ StEntry StLabel.hint-text, .popup-menu .search-entry StLabel.hint-text {
 .popup-menu .popup-menu-content {
   padding: 10px 0;
   font-weight: normal;
+  background-color: rgba(241, 241, 241, 0.85);
 }
 
 .popup-menu .popup-menu-item {

--- a/src/main/gnome-shell/shell-40-0/gnome-shell-light-grey.css
+++ b/src/main/gnome-shell/shell-40-0/gnome-shell-light-grey.css
@@ -2531,6 +2531,7 @@ StEntry StLabel.hint-text, .popup-menu .search-entry StLabel.hint-text {
 .popup-menu .popup-menu-content {
   padding: 10px 0;
   font-weight: normal;
+  background-color: rgba(241, 241, 241, 0.85);
 }
 
 .popup-menu .popup-menu-item {

--- a/src/main/gnome-shell/shell-40-0/gnome-shell-light-orange.css
+++ b/src/main/gnome-shell/shell-40-0/gnome-shell-light-orange.css
@@ -2531,6 +2531,7 @@ StEntry StLabel.hint-text, .popup-menu .search-entry StLabel.hint-text {
 .popup-menu .popup-menu-content {
   padding: 10px 0;
   font-weight: normal;
+  background-color: rgba(241, 241, 241, 0.85);
 }
 
 .popup-menu .popup-menu-item {

--- a/src/main/gnome-shell/shell-40-0/gnome-shell-light-pink.css
+++ b/src/main/gnome-shell/shell-40-0/gnome-shell-light-pink.css
@@ -2531,6 +2531,7 @@ StEntry StLabel.hint-text, .popup-menu .search-entry StLabel.hint-text {
 .popup-menu .popup-menu-content {
   padding: 10px 0;
   font-weight: normal;
+  background-color: rgba(241, 241, 241, 0.85);
 }
 
 .popup-menu .popup-menu-item {

--- a/src/main/gnome-shell/shell-40-0/gnome-shell-light-purple.css
+++ b/src/main/gnome-shell/shell-40-0/gnome-shell-light-purple.css
@@ -2531,6 +2531,7 @@ StEntry StLabel.hint-text, .popup-menu .search-entry StLabel.hint-text {
 .popup-menu .popup-menu-content {
   padding: 10px 0;
   font-weight: normal;
+  background-color: rgba(241, 241, 241, 0.85);
 }
 
 .popup-menu .popup-menu-item {

--- a/src/main/gnome-shell/shell-40-0/gnome-shell-light-red.css
+++ b/src/main/gnome-shell/shell-40-0/gnome-shell-light-red.css
@@ -2531,6 +2531,7 @@ StEntry StLabel.hint-text, .popup-menu .search-entry StLabel.hint-text {
 .popup-menu .popup-menu-content {
   padding: 10px 0;
   font-weight: normal;
+  background-color: rgba(241, 241, 241, 0.85);
 }
 
 .popup-menu .popup-menu-item {

--- a/src/main/gnome-shell/shell-40-0/gnome-shell-light-solid-blue.css
+++ b/src/main/gnome-shell/shell-40-0/gnome-shell-light-solid-blue.css
@@ -2531,6 +2531,7 @@ StEntry StLabel.hint-text, .popup-menu .search-entry StLabel.hint-text {
 .popup-menu .popup-menu-content {
   padding: 10px 0;
   font-weight: normal;
+  background-color: #f1f1f1;
 }
 
 .popup-menu .popup-menu-item {

--- a/src/main/gnome-shell/shell-40-0/gnome-shell-light-solid-green.css
+++ b/src/main/gnome-shell/shell-40-0/gnome-shell-light-solid-green.css
@@ -2531,6 +2531,7 @@ StEntry StLabel.hint-text, .popup-menu .search-entry StLabel.hint-text {
 .popup-menu .popup-menu-content {
   padding: 10px 0;
   font-weight: normal;
+  background-color: #f1f1f1;
 }
 
 .popup-menu .popup-menu-item {

--- a/src/main/gnome-shell/shell-40-0/gnome-shell-light-solid-grey.css
+++ b/src/main/gnome-shell/shell-40-0/gnome-shell-light-solid-grey.css
@@ -2531,6 +2531,7 @@ StEntry StLabel.hint-text, .popup-menu .search-entry StLabel.hint-text {
 .popup-menu .popup-menu-content {
   padding: 10px 0;
   font-weight: normal;
+  background-color: #f1f1f1;
 }
 
 .popup-menu .popup-menu-item {

--- a/src/main/gnome-shell/shell-40-0/gnome-shell-light-solid-orange.css
+++ b/src/main/gnome-shell/shell-40-0/gnome-shell-light-solid-orange.css
@@ -2531,6 +2531,7 @@ StEntry StLabel.hint-text, .popup-menu .search-entry StLabel.hint-text {
 .popup-menu .popup-menu-content {
   padding: 10px 0;
   font-weight: normal;
+  background-color: #f1f1f1;
 }
 
 .popup-menu .popup-menu-item {

--- a/src/main/gnome-shell/shell-40-0/gnome-shell-light-solid-pink.css
+++ b/src/main/gnome-shell/shell-40-0/gnome-shell-light-solid-pink.css
@@ -2531,6 +2531,7 @@ StEntry StLabel.hint-text, .popup-menu .search-entry StLabel.hint-text {
 .popup-menu .popup-menu-content {
   padding: 10px 0;
   font-weight: normal;
+  background-color: #f1f1f1;
 }
 
 .popup-menu .popup-menu-item {

--- a/src/main/gnome-shell/shell-40-0/gnome-shell-light-solid-purple.css
+++ b/src/main/gnome-shell/shell-40-0/gnome-shell-light-solid-purple.css
@@ -2531,6 +2531,7 @@ StEntry StLabel.hint-text, .popup-menu .search-entry StLabel.hint-text {
 .popup-menu .popup-menu-content {
   padding: 10px 0;
   font-weight: normal;
+  background-color: #f1f1f1;
 }
 
 .popup-menu .popup-menu-item {

--- a/src/main/gnome-shell/shell-40-0/gnome-shell-light-solid-red.css
+++ b/src/main/gnome-shell/shell-40-0/gnome-shell-light-solid-red.css
@@ -2531,6 +2531,7 @@ StEntry StLabel.hint-text, .popup-menu .search-entry StLabel.hint-text {
 .popup-menu .popup-menu-content {
   padding: 10px 0;
   font-weight: normal;
+  background-color: #f1f1f1;
 }
 
 .popup-menu .popup-menu-item {

--- a/src/main/gnome-shell/shell-40-0/gnome-shell-light-solid-yellow.css
+++ b/src/main/gnome-shell/shell-40-0/gnome-shell-light-solid-yellow.css
@@ -2531,6 +2531,7 @@ StEntry StLabel.hint-text, .popup-menu .search-entry StLabel.hint-text {
 .popup-menu .popup-menu-content {
   padding: 10px 0;
   font-weight: normal;
+  background-color: #f1f1f1;
 }
 
 .popup-menu .popup-menu-item {

--- a/src/main/gnome-shell/shell-40-0/gnome-shell-light-solid.css
+++ b/src/main/gnome-shell/shell-40-0/gnome-shell-light-solid.css
@@ -2531,6 +2531,7 @@ StEntry StLabel.hint-text, .popup-menu .search-entry StLabel.hint-text {
 .popup-menu .popup-menu-content {
   padding: 10px 0;
   font-weight: normal;
+  background-color: #f1f1f1;
 }
 
 .popup-menu .popup-menu-item {

--- a/src/main/gnome-shell/shell-40-0/gnome-shell-light-yellow.css
+++ b/src/main/gnome-shell/shell-40-0/gnome-shell-light-yellow.css
@@ -2531,6 +2531,7 @@ StEntry StLabel.hint-text, .popup-menu .search-entry StLabel.hint-text {
 .popup-menu .popup-menu-content {
   padding: 10px 0;
   font-weight: normal;
+  background-color: rgba(241, 241, 241, 0.85);
 }
 
 .popup-menu .popup-menu-item {

--- a/src/main/gnome-shell/shell-40-0/gnome-shell-light.css
+++ b/src/main/gnome-shell/shell-40-0/gnome-shell-light.css
@@ -2531,6 +2531,7 @@ StEntry StLabel.hint-text, .popup-menu .search-entry StLabel.hint-text {
 .popup-menu .popup-menu-content {
   padding: 10px 0;
   font-weight: normal;
+  background-color: rgba(241, 241, 241, 0.85);
 }
 
 .popup-menu .popup-menu-item {


### PR DESCRIPTION
Hello,

I've noticed that the background color of popup menu for the light themes are very dark (seems similar to the dark themes one), but the font color is also dark, making the whole very hard to read.

This is happening at least on Debian 12, Gnome 42 (I tried on a virgin account, with only the theme installed globally).

I propose to fix this with an additional `background-color` property in `gnome-shell.css`.
The only issue remaining is when the mouse hover away from the selection, the selection becomes very dark again.
I don't know how that can be fixed, but it is really a minor issue.

The fix contains many changes, but these were actually generated with the following sed scripts (we go get the background-color property from `#panel`, then copy it back to `popup-menu-content`).

    sed -nri '
    :A; p; /^#panel \{/{ :a; n; /background-color/{h; b B}; p; b a }; n; b A;
    :B; p; /popup-menu-content \{/{ :b; n; /font-weight/{p; g; b C}; p; b b }; n; b B;
    :C; p; n; b C;
    ' *.css